### PR TITLE
correct brightness when converting from xy to rgb 

### DIFF
--- a/Arduino/EspLight-fridgefire/EspLight-fridgefire.ino
+++ b/Arduino/EspLight-fridgefire/EspLight-fridgefire.ino
@@ -111,29 +111,15 @@ void convert_xy()
   g = g * rgb_multiplier[1] / 100;
   b = b * rgb_multiplier[2] / 100;
 
-  if (r > b && r > g) {
-    // red is biggest
-    if (r > 1.0f) {
-      g = g / r;
-      b = b / r;
-      r = 1.0f;
-    }
-  }
-  else if (g > b && g > r) {
-    // green is biggest
-    if (g > 1.0f) {
-      r = r / g;
-      b = b / g;
-      g = 1.0f;
-    }
-  }
-  else if (b > r && b > g) {
-    // blue is biggest
-    if (b > 1.0f) {
-      r = r / b;
-      g = g / b;
-      b = 1.0f;
-    }
+  float maxv = 0;// calc the maximum value of r g and b
+  if (r > maxv) maxv = r;
+  if (g > maxv) maxv = g;
+  if (b > maxv) maxv = b;
+
+  if (maxv > 0) {// only if maximum value is greater than zero, otherwise there would be division by zero
+    r /= maxv;   // scale to maximum so the brightest light is always 1.0
+    g /= maxv;
+    b /= maxv;
   }
 
   r = r < 0 ? 0 : r;

--- a/Arduino/Generic_RGBW_Light/Generic_RGBW_Light.ino
+++ b/Arduino/Generic_RGBW_Light/Generic_RGBW_Light.ino
@@ -123,29 +123,15 @@ void convert_xy()
   g = g <= 0.0031308f ? 12.92f * g : (1.0f + 0.055f) * pow(g, (1.0f / 2.4f)) - 0.055f;
   b = b <= 0.0031308f ? 12.92f * b : (1.0f + 0.055f) * pow(b, (1.0f / 2.4f)) - 0.055f;
 
-  if (r > b && r > g) {
-    // red is biggest
-    if (r > 1.0f) {
-      g = g / r;
-      b = b / r;
-      r = 1.0f;
-    }
-  }
-  else if (g > b && g > r) {
-    // green is biggest
-    if (g > 1.0f) {
-      r = r / g;
-      b = b / g;
-      g = 1.0f;
-    }
-  }
-  else if (b > r && b > g) {
-    // blue is biggest
-    if (b > 1.0f) {
-      r = r / b;
-      g = g / b;
-      b = 1.0f;
-    }
+  float maxv = 0;// calc the maximum value of r g and b
+  if (r > maxv) maxv = r;
+  if (g > maxv) maxv = g;
+  if (b > maxv) maxv = b;
+
+  if (maxv > 0) {// only if maximum value is greater than zero, otherwise there would be division by zero
+    r /= maxv;   // scale to maximum so the brightest light is always 1.0
+    g /= maxv;
+    b /= maxv;
   }
 
   r = r < 0 ? 0 : r;

--- a/Arduino/Generic_RGB_CCT_Light/Generic_RGB_CCT_Light.ino
+++ b/Arduino/Generic_RGB_CCT_Light/Generic_RGB_CCT_Light.ino
@@ -120,29 +120,15 @@ void convert_xy()
   g = g <= 0.0031308f ? 12.92f * g : (1.0f + 0.055f) * pow(g, (1.0f / 2.4f)) - 0.055f;
   b = b <= 0.0031308f ? 12.92f * b : (1.0f + 0.055f) * pow(b, (1.0f / 2.4f)) - 0.055f;
 
-  if (r > b && r > g) {
-    // red is biggest
-    if (r > 1.0f) {
-      g = g / r;
-      b = b / r;
-      r = 1.0f;
-    }
-  }
-  else if (g > b && g > r) {
-    // green is biggest
-    if (g > 1.0f) {
-      r = r / g;
-      b = b / g;
-      g = 1.0f;
-    }
-  }
-  else if (b > r && b > g) {
-    // blue is biggest
-    if (b > 1.0f) {
-      r = r / b;
-      g = g / b;
-      b = 1.0f;
-    }
+  float maxv = 0;// calc the maximum value of r g and b
+  if (r > maxv) maxv = r;
+  if (g > maxv) maxv = g;
+  if (b > maxv) maxv = b;
+
+  if (maxv > 0) {// only if maximum value is greater than zero, otherwise there would be division by zero
+    r /= maxv;   // scale to maximum so the brightest light is always 1.0
+    g /= maxv;
+    b /= maxv;
   }
 
   r = r < 0 ? 0 : r;

--- a/Arduino/Generic_RGB_Light/Generic_RGB_Light.ino
+++ b/Arduino/Generic_RGB_Light/Generic_RGB_Light.ino
@@ -117,29 +117,15 @@ void convert_xy()
   g = g <= 0.0031308f ? 12.92f * g : (1.0f + 0.055f) * pow(g, (1.0f / 2.4f)) - 0.055f;
   b = b <= 0.0031308f ? 12.92f * b : (1.0f + 0.055f) * pow(b, (1.0f / 2.4f)) - 0.055f;
 
-  if (r > b && r > g) {
-    // red is biggest
-    if (r > 1.0f) {
-      g = g / r;
-      b = b / r;
-      r = 1.0f;
-    }
-  }
-  else if (g > b && g > r) {
-    // green is biggest
-    if (g > 1.0f) {
-      r = r / g;
-      b = b / g;
-      g = 1.0f;
-    }
-  }
-  else if (b > r && b > g) {
-    // blue is biggest
-    if (b > 1.0f) {
-      r = r / b;
-      g = g / b;
-      b = 1.0f;
-    }
+  float maxv = 0;// calc the maximum value of r g and b
+  if (r > maxv) maxv = r;
+  if (g > maxv) maxv = g;
+  if (b > maxv) maxv = b;
+
+  if (maxv > 0) {// only if maximum value is greater than zero, otherwise there would be division by zero
+    r /= maxv;   // scale to maximum so the brightest light is always 1.0
+    g /= maxv;
+    b /= maxv;
   }
 
   r = r < 0 ? 0 : r;

--- a/Arduino/MY92XX_RGBW_Light/MY92XX_RGBW_Light.ino
+++ b/Arduino/MY92XX_RGBW_Light/MY92XX_RGBW_Light.ino
@@ -108,23 +108,15 @@ void convert_xy()
   float g = -X * 0.9689f + Y * 1.8758f + Z * 0.0415f;
   float b =  X * 0.0557f - Y * 0.2040f + Z * 1.0570f;
 
-  if (r > b && r > g && r > 1.0f) {
-    // red is too big
-    g = g / r;
-    b = b / r;
-    r = 1.0f;
-  }
-  else if (g > b && g > r && g > 1.0f) {
-    // green is too big
-    r = r / g;
-    b = b / g;
-    g = 1.0f;
-  }
-  else if (b > r && b > g && b > 1.0f) {
-    // blue is too big
-    r = r / b;
-    g = g / b;
-    b = 1.0f;
+  float maxv = 0;// calc the maximum value of r g and b
+  if (r > maxv) maxv = r;
+  if (g > maxv) maxv = g;
+  if (b > maxv) maxv = b;
+
+  if (maxv > 0) {// only if maximum value is greater than zero, otherwise there would be division by zero
+    r /= maxv;   // scale to maximum so the brightest light is always 1.0
+    g /= maxv;
+    b /= maxv;
   }
 
   // Apply gamma correction

--- a/Arduino/SK6812HueStrip/SK6812HueStrip.ino
+++ b/Arduino/SK6812HueStrip/SK6812HueStrip.ino
@@ -123,29 +123,15 @@ void convert_xy(uint8_t light)
   g = g <= 0.04045f ? g / 12.92f : pow((g + 0.055f) / (1.0f + 0.055f), 2.4f);
   b = b <= 0.04045f ? b / 12.92f : pow((b + 0.055f) / (1.0f + 0.055f), 2.4f);
 
-  if (r > b && r > g) {
-    // red is biggest
-    if (r > 1.0f) {
-      g = g / r;
-      b = b / r;
-      r = 1.0f;
-    }
-  }
-  else if (g > b && g > r) {
-    // green is biggest
-    if (g > 1.0f) {
-      r = r / g;
-      b = b / g;
-      g = 1.0f;
-    }
-  }
-  else if (b > r && b > g) {
-    // blue is biggest
-    if (b > 1.0f) {
-      r = r / b;
-      g = g / b;
-      b = 1.0f;
-    }
+  float maxv = 0;// calc the maximum value of r g and b
+  if (r > maxv) maxv = r;
+  if (g > maxv) maxv = g;
+  if (b > maxv) maxv = b;
+
+  if (maxv > 0) {// only if maximum value is greater than zero, otherwise there would be division by zero
+    r /= maxv;   // scale to maximum so the brightest light is always 1.0
+    g /= maxv;
+    b /= maxv;
   }
 
   r = r < 0 ? 0 : r;

--- a/Arduino/WS2811_adjustable/WS2811_adjustable.ino
+++ b/Arduino/WS2811_adjustable/WS2811_adjustable.ino
@@ -126,48 +126,15 @@ void convert_xy(uint8_t light)
   g = g * rgb_multiplier[1] / 100;
   b = b * rgb_multiplier[2] / 100;
 
-  if (r > b && r > g && r > 1.0f) {
-    // red is too big
-    g = g / r;
-    b = b / r;
-    r = 1.0f;
-  }
-  else if (g > b && g > r && g > 1.0f) {
-    // green is too big
-    r = r / g;
-    b = b / g;
-    g = 1.0f;
-  }
-  else if (b > r && b > g && b > 1.0f) {
-    // blue is too big
-    r = r / b;
-    g = g / b;
-    b = 1.0f;
-  }
+  float maxv = 0;// calc the maximum value of r g and b
+  if (r > maxv) maxv = r;
+  if (g > maxv) maxv = g;
+  if (b > maxv) maxv = b;
 
-  if (r > b && r > g) {
-    // red is biggest
-    if (r > 1.0f) {
-      g = g / r;
-      b = b / r;
-      r = 1.0f;
-    }
-  }
-  else if (g > b && g > r) {
-    // green is biggest
-    if (g > 1.0f) {
-      r = r / g;
-      b = b / g;
-      g = 1.0f;
-    }
-  }
-  else if (b > r && b > g) {
-    // blue is biggest
-    if (b > 1.0f) {
-      r = r / b;
-      g = g / b;
-      b = 1.0f;
-    }
+  if (maxv > 0) {// only if maximum value is greater than zero, otherwise there would be division by zero
+    r /= maxv;   // scale to maximum so the brightest light is always 1.0
+    g /= maxv;
+    b /= maxv;
   }
 
   r = r < 0 ? 0 : r;

--- a/Arduino/WS2812BHueRing/WS2812BHueRing.ino
+++ b/Arduino/WS2812BHueRing/WS2812BHueRing.ino
@@ -119,29 +119,15 @@ void convert_xy(uint8_t light)
   g = g <= 0.04045f ? g / 12.92f : pow((g + 0.055f) / (1.0f + 0.055f), 2.4f);
   b = b <= 0.04045f ? b / 12.92f : pow((b + 0.055f) / (1.0f + 0.055f), 2.4f);
 
-  if (r > b && r > g) {
-    // red is biggest
-    if (r > 1.0f) {
-      g = g / r;
-      b = b / r;
-      r = 1.0f;
-    }
-  }
-  else if (g > b && g > r) {
-    // green is biggest
-    if (g > 1.0f) {
-      r = r / g;
-      b = b / g;
-      g = 1.0f;
-    }
-  }
-  else if (b > r && b > g) {
-    // blue is biggest
-    if (b > 1.0f) {
-      r = r / b;
-      g = g / b;
-      b = 1.0f;
-    }
+  float maxv = 0;// calc the maximum value of r g and b
+  if (r > maxv) maxv = r;
+  if (g > maxv) maxv = g;
+  if (b > maxv) maxv = b;
+
+  if (maxv > 0) {// only if maximum value is greater than zero, otherwise there would be division by zero
+    r /= maxv;   // scale to maximum so the brightest light is always 1.0
+    g /= maxv;
+    b /= maxv;
   }
 
   r = r < 0 ? 0 : r;

--- a/Arduino/WS2812BHueStrip/WS2812BHueStrip.ino
+++ b/Arduino/WS2812BHueStrip/WS2812BHueStrip.ino
@@ -124,29 +124,15 @@ void convert_xy(uint8_t light)
   g = g <= 0.04045f ? g / 12.92f : pow((g + 0.055f) / (1.0f + 0.055f), 2.4f);
   b = b <= 0.04045f ? b / 12.92f : pow((b + 0.055f) / (1.0f + 0.055f), 2.4f);
 
-  if (r > b && r > g) {
-    // red is biggest
-    if (r > 1.0f) {
-      g = g / r;
-      b = b / r;
-      r = 1.0f;
-    }
-  }
-  else if (g > b && g > r) {
-    // green is biggest
-    if (g > 1.0f) {
-      r = r / g;
-      b = b / g;
-      g = 1.0f;
-    }
-  }
-  else if (b > r && b > g) {
-    // blue is biggest
-    if (b > 1.0f) {
-      r = r / b;
-      g = g / b;
-      b = 1.0f;
-    }
+  float maxv = 0;// calc the maximum value of r g and b
+  if (r > maxv) maxv = r;
+  if (g > maxv) maxv = g;
+  if (b > maxv) maxv = b;
+
+  if (maxv > 0) {// only if maximum value is greater than zero, otherwise there would be division by zero
+    r /= maxv;   // scale to maximum so the brightest light is always 1.0
+    g /= maxv;
+    b /= maxv;
   }
 
   r = r < 0 ? 0 : r;

--- a/Arduino/fastLED_SM16726_RGBW_Bulb/fastLED_SM16726_RGBW_Bulb.ino
+++ b/Arduino/fastLED_SM16726_RGBW_Bulb/fastLED_SM16726_RGBW_Bulb.ino
@@ -163,29 +163,15 @@ void convert_xy()
   g = g <= 0.0031308f ? 12.92f * g : (1.0f + 0.055f) * pow(g, (1.0f / 2.4f)) - 0.055f;
   b = b <= 0.0031308f ? 12.92f * b : (1.0f + 0.055f) * pow(b, (1.0f / 2.4f)) - 0.055f;
 
-  if (r > b && r > g) {
-    // red is biggest
-    if (r > 1.0f) {
-      g = g / r;
-      b = b / r;
-      r = 1.0f;
-    }
-  }
-  else if (g > b && g > r) {
-    // green is biggest
-    if (g > 1.0f) {
-      r = r / g;
-      b = b / g;
-      g = 1.0f;
-    }
-  }
-  else if (b > r && b > g) {
-    // blue is biggest
-    if (b > 1.0f) {
-      r = r / b;
-      g = g / b;
-      b = 1.0f;
-    }
+  float maxv = 0;// calc the maximum value of r g and b
+  if (r > maxv) maxv = r;
+  if (g > maxv) maxv = g;
+  if (b > maxv) maxv = b;
+
+  if (maxv > 0) {// only if maximum value is greater than zero, otherwise there would be division by zero
+    r /= maxv;   // scale to maximum so the brightest light is always 1.0
+    g /= maxv;
+    b /= maxv;
   }
 
   r = r < 0 ? 0 : r;


### PR DESCRIPTION
When selecting white light in the hue app from xy colo space, pure white will only reach 1/3 of the maximum brighness. Brightness ist supposed to be added separately.

```
  float maxv = 0;// calc the maximum value of r g and b
  if (r > maxv) maxv = r;
  if (g > maxv) maxv = g;
  if (b > maxv) maxv = b;

  if (maxv > 0) {// only if maximum value is greater than zero, otherwise there would be division by zero
    r /= maxv;   // scale to maximum so the brightest light is always 1.0
    g /= maxv;
    b /= maxv;
  }
```
this replaced the previous correction for too big rgb values.
The biggest channel is scaled to 1 and all other channels according to their previous value.
By dividing by the biggest channel all values are ensured to be maximum 1 an minimum 0.

Fixes #9 