### PR TITLE
Better description for "transitionLeds" value

### DIFF
--- a/Arduino/Generic_WS2812_Strip/Generic_WS2812_Strip.ino
+++ b/Arduino/Generic_WS2812_Strip/Generic_WS2812_Strip.ino
@@ -35,7 +35,7 @@ bool hwSwitch = false;
 
 uint8_t lightsCount = 3;
 uint16_t pixelCount = 60, lightLedsCount;
-uint8_t transitionLeds = 6; // must be even number
+uint8_t transitionLeds = 6; // pixelCount must be divisible by this value
 
 
 


### PR DESCRIPTION
Updated description for "transitionLeds". Values that are not divisible are resulting in some pixels that don't work properly.