### PR TITLE
Added Fade Functionality for use with Dimmer Controls

### DIFF
--- a/Arduino/Generic_WS2812_Strip/Generic_WS2812_Strip.ino
+++ b/Arduino/Generic_WS2812_Strip/Generic_WS2812_Strip.ino
@@ -29,7 +29,7 @@ bool inTransition, entertainmentRun, useDhcp = true;
 byte mac[6], packetBuffer[46];
 unsigned long lastEPMillis;
 uint8_t fade = 5;
-int fadeTime = 80;
+int fadeTime = 90;
 unsigned long currentTime = millis();
 unsigned long loopTime = currentTime;
 int fadeDirection = 0;	 


### PR DESCRIPTION
Added an appropriate response to the bri_inc command. It will now respond the same way that a Hue Bulb does. This will allow you to use a hue dimmer switch or Tradfri dimmer to adjust the level of the lights. If your light is at 100% and you press and hold the down button, the light will fade down until the button is released and then stop.

For the bri_inc value:
Any negative value will cause the light to start dimming.
Any positive value will cause the light to start brightening.
A value of 0 will cause the light to stop changing.

The transitiontime passed along with the bri_inc command can be used to adjust the fade time.  The higher the value passed, the longer it will take to change the light.