### PR TITLE
UDP support for ESPHome ESP32

### DIFF
--- a/ESPHome/ESP32WiFiUDP/diyhueudp.h
+++ b/ESPHome/ESP32WiFiUDP/diyhueudp.h
@@ -1,0 +1,58 @@
+#include "esphome.h"
+#include <WiFiUdp.h>
+#include <WiFi.h>
+class diyhueudp : public Component {
+ public:
+  WiFiUDP Udp;
+  int lastUDPmilsec;
+  int entertainmentTimeout = 1500;
+  int initialized = 0;
+
+  //TODO: Can this be removed?
+  void setup() override {
+    
+  }
+  void loop() override {
+    if (entertainment_switch->state) {
+      if ((millis() - lastUDPmilsec) >= entertainmentTimeout) {
+        entertainment_switch->turn_off();
+      }
+    }
+    if (!initialized && WiFi.status() == WL_CONNECTED)
+    {
+    	initialized = 1;
+    	Udp.begin(2100);
+    }
+    if (initialized)
+    {
+    	entertainment();
+    }
+  }
+  void entertainment() {
+    int packetSize = Udp.parsePacket(); //begin parsing udp packet
+    if (packetSize) {
+      //turn off white_led when entertainment starts
+      auto call = white_led->turn_off();
+      call.set_transition_length(0);
+      call.perform();
+      if (!entertainment_switch->state) {
+        entertainment_switch->turn_on();
+      }
+      lastUDPmilsec = millis(); //reset timeout value
+      byte packetBuffer[8];
+      Udp.read(packetBuffer, packetSize);
+      call = color_led->turn_on();
+      if (((packetBuffer[1])+(packetBuffer[2])+(packetBuffer[3])) == 0) {
+        call.set_rgb(0,0,0);
+        call.set_brightness(0);
+        call.set_transition_length(0);
+        call.perform();
+      } else {
+        call.set_rgb((float)((packetBuffer[1])/(float)255), (float)((packetBuffer[2])/(float)255), (float)((packetBuffer[3])/(float)255));
+        call.set_transition_length(0);
+        call.set_brightness((float)((packetBuffer[4])/(float)255));
+        call.perform();
+      }
+    }
+  }
+};

--- a/ESPHome/ESP32WiFiUDP/rgb-cct-fastled.yaml
+++ b/ESPHome/ESP32WiFiUDP/rgb-cct-fastled.yaml
@@ -1,0 +1,139 @@
+esphome:
+  name: room_diyhue
+  platform: ESP32
+  board: esp32doit-devkit-v1
+  includes:
+    - diyhueudp.h
+
+custom_component:
+- lambda: |-
+    auto diyhue = new diyhueudp();
+    return {diyhue};
+    
+#  on_boot:
+#    then:
+#      - light.turn_on:
+#          id: white_led
+#          brightness: 100%
+#          color_temperature: 4000 K
+
+ota:
+  password: "SUPER-SECRET-PASSWORD"
+    
+wifi:
+  ssid: "SUPER-SECRET-SSID"
+  password: "SUPER-SECRET-PASSWORD"
+  
+  manual_ip:
+    static_ip: STATIC_IP
+    gateway: GATEWAY
+    subnet: SUBNET
+  
+  ap:
+   ssid: "LIGHT-NAME"
+  
+# Enable logging
+logger:
+  level: WARN
+
+# Enable Home Assistant API
+api:
+  password: "SUPER-SECRET-PASSWORD"
+  reboot_timeout: 0s
+
+output:
+  - platform: esp8266_pwm
+    pin: GPIO5
+    id: cold_white_gpio
+    frequency: 1000 Hz
+    inverted: False
+    min_power: 0
+    max_power: 0.7
+    
+  - platform: esp8266_pwm
+    pin: GPIO12
+    id: warm_white_gpio
+    frequency: 1000 Hz
+    inverted: False
+    min_power: 0
+    max_power: 0.7
+    
+  - platform: gpio
+    pin: GPIO13
+    id: fast_led_pwr
+    inverted: True
+    
+light:
+  - platform: cwww
+    id: white_led
+    name: "white_led"
+    cold_white: cold_white_gpio
+    warm_white: warm_white_gpio
+    cold_white_color_temperature: 6500 K
+    warm_white_color_temperature: 2000 K
+    gamma_correct: 0.8
+    default_transition_length: 0.4s
+
+  - platform: fastled_spi
+    id: color_led
+    chipset: SM16716
+    data_pin: GPIO14
+    clock_pin: GPIO4
+    num_leds: 1
+    rgb_order: BGR
+    name: "color_led"
+    default_transition_length: 0.4s
+    gamma_correct: 2.6
+    effects:
+      - random:
+          name: Random Effect With Custom Values
+          transition_length: 5s
+          update_interval: 3s
+
+text_sensor:
+  - platform: template
+    name: "light_id"
+    id: light_id
+    lambda: |-
+      return {"esphome_diyhue_light;SUPER-SECRET-MAC;LIGHT-NAME;CT-BOOST;RGB-BOOST"};
+    update_interval: 24h
+    
+switch:
+  - platform: template
+    name: alert
+    id: alert
+    optimistic: true
+    turn_on_action:
+      - light.turn_off: color_led
+      - light.turn_on:
+          id: white_led
+          brightness: 100%
+          color_temperature: 4000 K
+      - delay: 1s
+      - light.turn_on:
+          id: white_led
+          brightness: 10%
+          color_temperature: 4000 K
+      - delay: 1s
+      - light.turn_on:
+          id: white_led
+          brightness: 100%
+          color_temperature: 4000 K
+      - delay: 1s
+      - light.turn_on:
+          id: white_led
+          brightness: 10%
+          color_temperature: 4000 K
+      - delay: 1s
+      - light.turn_on:
+          id: white_led
+          brightness: 100%
+          color_temperature: 4000 K
+      - switch.turn_off: alert
+  - platform: template
+    name: entertainment_switch
+    id: entertainment_switch
+    optimistic: true
+    
+web_server:
+  port: 80


### PR DESCRIPTION
Hello!

I made some changes to the ESPHome UDP library so that it supports the ESP32. 
Apparently the ESP32 could not create a UDP server before a connection was made. In order to fix this I added a code that constantly polls for the WiFi state to become "connected".
Porting the async version of the code to the ESP32 resulted in a failure which seems to block all network connectivity.

Thank you