### PR TITLE
Updated Esphome yaml with automatic text sensor

### DIFF
--- a/ESPHome/rgb-cct-fastled.yaml
+++ b/ESPHome/rgb-cct-fastled.yaml
@@ -103,7 +103,7 @@ text_sensor:
       strcat( response, WiFi.macAddress().c_str());
       strcat( response, ";");
       strcat( response, App.get_name().c_str());
-      strcat( response, ";0;0" ); //";CT-BOOST;RGB-BOOST"
+      strcat( response, ";0;0" ); // ;CT_BOOST;RGB_BOOST values go here
       return { response };
     update_interval: 24h
              

--- a/ESPHome/rgb-cct-fastled.yaml
+++ b/ESPHome/rgb-cct-fastled.yaml
@@ -92,14 +92,21 @@ light:
           transition_length: 5s
           update_interval: 3s
 
-text_sensor:
-  - platform: template
-    name: "light_id"
-    id: light_id
-    lambda: |-
-      return {"esphome_diyhue_light;SUPER-SECRET-MAC;LIGHT-NAME;CT-BOOST;RGB-BOOST"};
-    update_interval: 24h
-    
+          text_sensor:
+            - platform: template
+              name: "light_id"
+              id: light_id
+              lambda: |-
+                char response[100];
+                memset( response, 0, 100 );
+                strcat( response, "esphome_diyhue_light;");
+                strcat( response, WiFi.macAddress().c_str());
+                strcat( response, ";");
+                strcat( response, App.get_name().c_str());
+                strcat( response, ";0;0" ); //";CT-BOOST;RGB-BOOST"
+                return { response };
+              update_interval: 24h
+             
 switch:
   - platform: template
     name: alert

--- a/ESPHome/rgb-cct-fastled.yaml
+++ b/ESPHome/rgb-cct-fastled.yaml
@@ -92,20 +92,20 @@ light:
           transition_length: 5s
           update_interval: 3s
 
-          text_sensor:
-            - platform: template
-              name: "light_id"
-              id: light_id
-              lambda: |-
-                char response[100];
-                memset( response, 0, 100 );
-                strcat( response, "esphome_diyhue_light;");
-                strcat( response, WiFi.macAddress().c_str());
-                strcat( response, ";");
-                strcat( response, App.get_name().c_str());
-                strcat( response, ";0;0" ); //";CT-BOOST;RGB-BOOST"
-                return { response };
-              update_interval: 24h
+text_sensor:
+  - platform: template
+    name: "light_id"
+    id: light_id
+    lambda: |-
+      char response[100];
+      memset( response, 0, 100 );
+      strcat( response, "esphome_diyhue_light;");
+      strcat( response, WiFi.macAddress().c_str());
+      strcat( response, ";");
+      strcat( response, App.get_name().c_str());
+      strcat( response, ";0;0" ); //";CT-BOOST;RGB-BOOST"
+      return { response };
+    update_interval: 24h
              
 switch:
   - platform: template


### PR DESCRIPTION
Text sensor now pulls light name and mac address from esphome automatically.  Only required config is CT-BOOST and RGB-BOOST.