### PR TITLE
link to esp8266-lighting-controllers

### DIFF
--- a/esp8266-lighting-controllers/README.md
+++ b/esp8266-lighting-controllers/README.md
@@ -1,0 +1,33 @@
+# ESP8266 Lighting controllers
+
+Full source: https://github.com/panovvv/esp8266-lighting-controllers
+
+* ESP-12 RGBCCT (5 channels) controller
+
+    * Prototype
+      ![prototype_photo.jpg](https://github.com/panovvv/esp8266-lighting-controllers/raw/master/esp12_rgbcct_led_strip_controller/breadboard/prototype_photo.jpg)
+    * PCB render
+      ![esp12_rgbcct.png](https://github.com/panovvv/esp8266-lighting-controllers/raw/master/esp12_rgbcct_led_strip_controller/pcb/renders/09_raytrace_left.png)
+    * PCB
+      
+      ![0_pcb.jpg](https://github.com/panovvv/esp8266-lighting-controllers/raw/master/esp12_rgbcct_led_strip_controller/pcb/photo/0_pcb.jpg)
+    * Regular enclosure
+      
+      ![1_regular_enclosure_open.jpg](https://github.com/panovvv/esp8266-lighting-controllers/raw/master/esp12_rgbcct_led_strip_controller/pcb/photo/1_regular_enclosure_open.jpg)
+      
+      ![2_regular_enclosure_closed.jpg](https://github.com/panovvv/esp8266-lighting-controllers/raw/master/esp12_rgbcct_led_strip_controller/pcb/photo/2_regular_enclosure_closed.jpg)
+      
+    * Waterproof enclosure
+      
+      ![3_waterproof_enclosure_open.jpg](https://github.com/panovvv/esp8266-lighting-controllers/raw/master/esp12_rgbcct_led_strip_controller/pcb/photo/3_waterproof_enclosure_open.jpg)
+      
+      ![4_waterproof_enclosure_closed.jpg](https://github.com/panovvv/esp8266-lighting-controllers/raw/master/esp12_rgbcct_led_strip_controller/pcb/photo/4_waterproof_enclosure_closed.jpg)
+    
+
+* ESP-01 Neopixel (WS2812) controller
+
+    * Schematic
+      ![schematic.jpg](https://github.com/panovvv/esp8266-lighting-controllers/raw/master/esp01_neopixel_controller/esp01_neopixel_controller-1.png)
+    * Prototype
+      ![prototype.jpg](https://github.com/panovvv/esp8266-lighting-controllers/raw/master/esp01_neopixel_controller/prototype.jpg)
+


### PR DESCRIPTION
I've been wanting to contribute these schematics, PCBs, and 3d models for quite a while, but couldn't settle on a best way to go about it. 
The following options have been considered:
1) Plain copy from esp8266-lighting-controllers repo to Lights repo. Pro: easiest of the options, Con: leaves us with 2 copies of the same files, that are bound to wildly diverge from one another eventually.
2) Include esp8266-lighting-controllers as a submodule into Lights repo. Pro: clear ownership distribution (I still maintain my repo, diyHue folks maintain the Lights repo), Con: more complicated to manage than plain git repo.
3) Link to esp8266-lighting-controllers from the Lights repo - this is what I eventually settled on. The only disadvantage I can think of is that this will look like a shameless self-plug lol :) 

Please chime in - which of the options do you guys prefer, I'd be happy to accommodate this PR to the way you run things in diyHue.